### PR TITLE
Set vpn network as underlying network

### DIFF
--- a/simple-rt-android/app/src/main/AndroidManifest.xml
+++ b/simple-rt-android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,10 @@
           package="com.viper.simplert">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-feature android:name="android.hardware.usb.accessory"/>
+
 
     <application
         android:allowBackup="true"
@@ -33,12 +35,12 @@
         <service
             android:name=".TetherService"
             android:permission="android.permission.BIND_VPN_SERVICE"
+
             android:process=":separate">
             <intent-filter>
                 <action android:name="android.net.VpnService"/>
             </intent-filter>
         </service>
-
     </application>
 
 </manifest>

--- a/simple-rt-android/app/src/main/AndroidManifest.xml
+++ b/simple-rt-android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
 
     <uses-feature android:name="android.hardware.usb.accessory"/>
 
-
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -35,7 +34,6 @@
         <service
             android:name=".TetherService"
             android:permission="android.permission.BIND_VPN_SERVICE"
-
             android:process=":separate">
             <intent-filter>
                 <action android:name="android.net.VpnService"/>


### PR DESCRIPTION
Set vpn network as underlying network safe for android 5.1 and more. 
Save compatibility with previous android versions.

Google play store still unavailable, but it helps me solve some stuff related to other apps.